### PR TITLE
Wrap glTF indices with dedicated types

### DIFF
--- a/Sources/SwiftGLTF/parser.swift
+++ b/Sources/SwiftGLTF/parser.swift
@@ -333,11 +333,11 @@ func loadTextureSampler(
 // テクスチャ読み込みヘルパー
 // en: Helper function to load texture sampler
 func loadTextureSampler(
-    textureIndex: Int,
+    textureIndex: TextureIndex,
     from gltf: GLTF, // TODO: All gltf objects are not needed. Just the textures are enough.
     textures: [Int: MDLTexture?]
 ) -> MDLTextureSampler? {
-    guard let texture = gltf.textures?[textureIndex],
+    guard let texture = gltf.textures?[textureIndex.value],
           let sourceIndex = texture.source else {
         return nil
     }
@@ -402,8 +402,8 @@ func extractUrl(for info: OcclusionTextureInfo?, from gltf: GLTF, baseURL: URL) 
     return extractUrl(textureIndex: textureIndex, from: gltf, baseURL: baseURL)
 }
 
-func extractUrl(textureIndex: Int, from gltf: GLTF, baseURL: URL) -> URL? {
-    guard let texture = gltf.textures?[textureIndex],
+func extractUrl(textureIndex: TextureIndex, from gltf: GLTF, baseURL: URL) -> URL? {
+    guard let texture = gltf.textures?[textureIndex.value],
           let sourceIndex = texture.source,
           let image = gltf.images?[sourceIndex],
           let uri = image.uri else {
@@ -476,7 +476,7 @@ private func makePositionVertex(
         throw NSError(domain: "GLTF", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid POSITION accessor"])
     }
     let positionVertex = VertexInfo(
-        data: try bufferLoader.extractData(accessorIndex: positionAccessorIndex),
+        data: try bufferLoader.extractData(accessorIndex: AccessorIndex(positionAccessorIndex)),
         componentFormat: positionVertexFormat.format,
         componentSize: positionVertexFormat.byteSize
     )
@@ -494,7 +494,7 @@ private func makeNormalVertex(
         return nil
     }
     return VertexInfo(
-        data: try bufferLoader.extractData(accessorIndex: normalIndex),
+        data: try bufferLoader.extractData(accessorIndex: AccessorIndex(normalIndex)),
         componentFormat: normalVertexFormat.format,
         componentSize: normalVertexFormat.byteSize
     )
@@ -511,7 +511,7 @@ private func makeTangentVertex(
         return nil
     }
     return VertexInfo(
-        data: try bufferLoader.extractData(accessorIndex: index),
+        data: try bufferLoader.extractData(accessorIndex: AccessorIndex(index)),
         componentFormat: format.format,
         componentSize: format.byteSize
     )
@@ -528,7 +528,7 @@ private func makeTexcoordVertex(
         return nil
     }
     return VertexInfo(
-        data: try bufferLoader.extractData(accessorIndex: index),
+        data: try bufferLoader.extractData(accessorIndex: AccessorIndex(index)),
         componentFormat: format.format,
         componentSize: format.byteSize
     )
@@ -545,7 +545,7 @@ private func makeModulationColorVertex(
         return nil
     }
     return VertexInfo(
-        data: try bufferLoader.extractData(accessorIndex: index),
+        data: try bufferLoader.extractData(accessorIndex: AccessorIndex(index)),
         componentFormat: format.format,
         componentSize: format.byteSize
     )
@@ -558,11 +558,11 @@ private func makeIndexInfo(
     bufferLoader: GLTFBufferLoader
 ) throws -> IndexInfo {
     if let indexAccessorIndex = primitive.indices {
-        guard accessors.count > indexAccessorIndex else {
+        guard accessors.count > indexAccessorIndex.value else {
             throw NSError(domain: "GLTF", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid indices reference"])
         }
 
-        let accessor = accessors[indexAccessorIndex]
+        let accessor = accessors[indexAccessorIndex.value]
         let indexData = try bufferLoader.extractData(accessorIndex: indexAccessorIndex)
         let indexCount = accessor.count
 

--- a/Sources/SwiftGLTFCore/Loader.swift
+++ b/Sources/SwiftGLTFCore/Loader.swift
@@ -18,17 +18,17 @@ public struct GLTFBufferLoader {
         } ?? []
     }
 
-    public func extractData(accessorIndex: Int) throws -> Data {
-        guard let accessor = gltf.accessors?[accessorIndex] else {
+    public func extractData(accessorIndex: AccessorIndex) throws -> Data {
+        guard let accessor = gltf.accessors?[accessorIndex.value] else {
             throw NSError(domain: "GLTF", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid accessor index"])
         }
 
         guard let bufferViewIndex = accessor.bufferView,
-              let bufferView = gltf.bufferViews?[bufferViewIndex] else {
+              let bufferView = gltf.bufferViews?[bufferViewIndex.value] else {
             throw NSError(domain: "GLTF", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid bufferView reference"])
         }
 
-        let buffer = loadedBuffers[bufferView.buffer]
+        let buffer = loadedBuffers[bufferView.buffer.value]
         let baseOffset = (accessor.byteOffset ?? 0) + (bufferView.byteOffset ?? 0)
         let accessorStride = accessor.type.components * accessor.componentType.size
         let bufferStride = bufferView.byteStride ?? accessorStride

--- a/Sources/SwiftGLTFCore/Types.swift
+++ b/Sources/SwiftGLTFCore/Types.swift
@@ -43,13 +43,57 @@ public struct PBRMetallicRoughness: Codable {
     public let metallicRoughnessTexture: TextureInfo?
 }
 
+public struct TextureIndex: Codable, Hashable, ExpressibleByIntegerLiteral {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    public init(integerLiteral value: Int) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try container.decode(Int.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
+public struct AccessorIndex: Codable, Hashable, ExpressibleByIntegerLiteral {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    public init(integerLiteral value: Int) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try container.decode(Int.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
 public struct TextureInfo: Codable {
-    public let index: Int
+    public let index: TextureIndex
     public let texCoord: Int?
 }
 
 public struct OcclusionTextureInfo: Codable {
-    public let index: Int
+    public let index: TextureIndex
     public let texCoord: Int?
     public let strength: Float?
 }
@@ -74,16 +118,60 @@ public struct Buffer: Codable {
     public let byteLength: Int
 }
 
+public struct BufferIndex: Codable, Hashable, ExpressibleByIntegerLiteral {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    public init(integerLiteral value: Int) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try container.decode(Int.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
 public struct BufferView: Codable {
-    public let buffer: Int
+    public let buffer: BufferIndex
     public let byteOffset: Int?
     public let byteLength: Int
     public let byteStride: Int?
     public let target: Int?
 }
 
+public struct BufferViewIndex: Codable, Hashable, ExpressibleByIntegerLiteral {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    public init(integerLiteral value: Int) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try container.decode(Int.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
 public struct Accessor: Codable {
-    public let bufferView: Int?
+    public let bufferView: BufferViewIndex?
     public let byteOffset: Int?
     public let componentType: GLTFComponentType
     public let count: Int
@@ -98,7 +186,7 @@ public struct Mesh: Codable {
 
 public struct Primitive: Codable {
     public let attributes: [String: Int]
-    public let indices: Int?
+    public let indices: AccessorIndex?
     public let material: Int?
     public let mode: GLTFPrimitiveMode?
 }
@@ -106,7 +194,7 @@ public struct Primitive: Codable {
 public struct Image: Codable {
     public let uri: String?
     public let mimeType: String?
-    public let bufferView: Int?
+    public let bufferView: BufferViewIndex?
     public let name: String?
 }
 

--- a/Tests/SwiftGLTFTests/Cube/CubeTests.swift
+++ b/Tests/SwiftGLTFTests/Cube/CubeTests.swift
@@ -83,8 +83,8 @@ struct CubeTests {
         let originalData = try Data(contentsOf: binURL)
 
         let posAccessorIndex = gltf.meshes![0].primitives[0].indices!
-        let accessor = gltf.accessors![posAccessorIndex]
-        let bufferView = gltf.bufferViews![accessor.bufferView!]
+        let accessor = gltf.accessors![posAccessorIndex.value]
+        let bufferView = gltf.bufferViews![accessor.bufferView!.value]
         let start = bufferView.byteOffset ?? 0
         let length = bufferView.byteLength
         let expectedIndexData = originalData.subdata(in: start..<(start + length))
@@ -105,7 +105,7 @@ struct CubeTests {
 
         let posAccessorIndex = gltf.meshes![0].primitives[0].attributes["POSITION"]!
         let accessor = gltf.accessors![posAccessorIndex]
-        let bufferView = gltf.bufferViews![accessor.bufferView!]
+        let bufferView = gltf.bufferViews![accessor.bufferView!.value]
         let start = bufferView.byteOffset ?? 0
         let length = bufferView.byteLength
         let expectedPositionData = originalData.subdata(in: start..<(start + length))
@@ -134,7 +134,7 @@ struct CubeTests {
 
         let posAccessorIndex = gltf.meshes![0].primitives[0].attributes["NORMAL"]!
         let accessor = gltf.accessors![posAccessorIndex]
-        let bufferView = gltf.bufferViews![accessor.bufferView!]
+        let bufferView = gltf.bufferViews![accessor.bufferView!.value]
         let start = bufferView.byteOffset ?? 0
         let length = bufferView.byteLength
         let expectedNormalData = originalData.subdata(in: start..<(start + length))
@@ -163,7 +163,7 @@ struct CubeTests {
 
         let posAccessorIndex = gltf.meshes![0].primitives[0].attributes["TEXCOORD_0"]!
         let accessor = gltf.accessors![posAccessorIndex]
-        let bufferView = gltf.bufferViews![accessor.bufferView!]
+        let bufferView = gltf.bufferViews![accessor.bufferView!.value]
         let start = bufferView.byteOffset ?? 0
         let length = bufferView.byteLength
         let expectedTexCoordData = originalData.subdata(in: start..<(start + length))

--- a/Tests/SwiftGLTFTests/CubeWithTexture/CubeWithTextureTests.swift
+++ b/Tests/SwiftGLTFTests/CubeWithTexture/CubeWithTextureTests.swift
@@ -15,7 +15,7 @@ struct CubeWithTextureTests {
 
         let posAccessorIndex = gltf.meshes![0].primitives[0].attributes["TEXCOORD_0"]!
         let accessor = gltf.accessors![posAccessorIndex]
-        let bufferView = gltf.bufferViews![accessor.bufferView!]
+        let bufferView = gltf.bufferViews![accessor.bufferView!.value]
         let start = bufferView.byteOffset ?? 0
         let length = bufferView.byteLength
         let expectedTexCoordData = originalData.subdata(in: start..<(start + length))
@@ -71,7 +71,7 @@ struct CubeWithTextureTests {
         let sampler = baseColor.textureSamplerValue!
 
         let textureIndex = gltf.materials![0].pbrMetallicRoughness!.baseColorTexture!.index
-        let samplerIndex = gltf.textures![textureIndex].sampler!
+        let samplerIndex = gltf.textures![textureIndex.value].sampler!
         let gltfSampler = gltf.samplers![samplerIndex]
 
         // compare filter modes

--- a/Tests/SwiftGLTFTests/TangentCube/TangentCubeTests.swift
+++ b/Tests/SwiftGLTFTests/TangentCube/TangentCubeTests.swift
@@ -15,7 +15,7 @@ struct TangentCubeTests {
 
         let posAccessorIndex = gltf.meshes![0].primitives[0].attributes["TANGENT"]!
         let accessor = gltf.accessors![posAccessorIndex]
-        let bufferView = gltf.bufferViews![accessor.bufferView!]
+        let bufferView = gltf.bufferViews![accessor.bufferView!.value]
         let start = bufferView.byteOffset ?? 0
         let length = bufferView.byteLength
         let expectedPositionData = originalData.subdata(in: start..<(start + length))


### PR DESCRIPTION
## Summary
- add `BufferIndex` and `BufferViewIndex` wrapper structs
- update `BufferView`, `Accessor`, and `Image` to use new index types
- adjust `GLTFBufferLoader` and unit tests for wrapped indices

## Testing
- `swift test` *(fails: no such module 'ModelIO' and 'Metal')*

------
https://chatgpt.com/codex/tasks/task_e_686a6803d870832dbcb99ef95ede445b