### PR TITLE
Add GLB decoding support

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -38,12 +38,13 @@ import SwiftGLTFRenderer
 
 // ...
 
-let gltfUrl = // URL to your glTF file
+let gltfUrl = // URL to your .glb file
 let data = try Data(contentsOf: gltfUrl)
-let gltf = try loadGLTF(from: data)
+let (gltf, bin) = try loadGLB(from: data)
 let asset = try makeMDLAsset(
     from: gltf,
-    baseURL: url.deletingLastPathComponent(),
+    baseURL: gltfUrl.deletingLastPathComponent(),
+    binaryChunk: bin,
     options: options
 )
 
@@ -62,7 +63,7 @@ view.addSubview(mtlView)
 ### File formats
 | Format              | Supported |
 |---------------------|-----------|
-| glTF Binary (.glb)  | ❌         |
+| glTF Binary (.glb)  | ✅         |
 | glTF JSON (.gltf)   | ✅         |
 
 ### Buffer formats

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ import SwiftGLTFRenderer
 
 // ...
 
-let gltfUrl = // URL to your glTF file
+let gltfUrl = // URL to your .glb file
 let data = try Data(contentsOf: gltfUrl)
-let gltf = try loadGLTF(from: data)
+let (gltf, bin) = try loadGLB(from: data)
 let asset = try makeMDLAsset(
     from: gltf,
-    baseURL: url.deletingLastPathComponent(),
+    baseURL: gltfUrl.deletingLastPathComponent(),
+    binaryChunk: bin,
     options: options
 )
 
@@ -63,7 +64,7 @@ view.addSubview(mtlView)
 ### File Formats
 | Format              | Supported |
 |---------------------|-----------|
-| glTF Binary (.glb)  | ❌         |
+| glTF Binary (.glb)  | ✅         |
 | glTF JSON (.gltf)   | ✅         |
 
 ### Buffer Formats

--- a/Sources/SwiftGLTF/parser.swift
+++ b/Sources/SwiftGLTF/parser.swift
@@ -99,6 +99,11 @@ public func loadGLTF(from data: Data) throws -> GLTF {
     return gltf
 }
 
+public func loadGLB(from data: Data) throws -> (GLTF, Data?) {
+    let result = try GLBDecoder.decode(data)
+    return (result.gltf, result.binaryChunk)
+}
+
 public func makeMDLMesh(
     from mesh: Mesh,
     using gltf: GLTF,
@@ -186,7 +191,7 @@ public func makeMDLMesh(
     return mdlMeshes
 }
 
-public func makeMDLAsset(from gltf: GLTF, baseURL: URL, options: GLTFDecodeOptions = .default) throws -> MDLAsset {
+public func makeMDLAsset(from gltf: GLTF, baseURL: URL, binaryChunk: Data? = nil, options: GLTFDecodeOptions = .default) throws -> MDLAsset {
     #if DEBUG
     let now = Date()
     #endif
@@ -194,7 +199,7 @@ public func makeMDLAsset(from gltf: GLTF, baseURL: URL, options: GLTFDecodeOptio
     let device = MTLCreateSystemDefaultDevice()!
     let allocator = MTKMeshBufferAllocator(device: device)
     let asset = MDLAsset(bufferAllocator: allocator)
-    let bufferLoader = try GLTFBufferLoader(gltf: gltf, baseURL: baseURL)
+    let bufferLoader = try GLTFBufferLoader(gltf: gltf, baseURL: baseURL, binaryChunk: binaryChunk)
     let preloadTextures = preloadRawTextures(gltf, baseURL: baseURL)
 
     // 全ての mesh を先に変換して保持（再利用のため）

--- a/Sources/SwiftGLTFCore/GLBDecoder.swift
+++ b/Sources/SwiftGLTFCore/GLBDecoder.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct GLBDecoder {
+    public static func decode(_ data: Data) throws -> (gltf: GLTF, binaryChunk: Data?) {
+        struct GLBError: LocalizedError {
+            var errorDescription: String?
+        }
+
+        func readUInt32LE(_ range: Range<Data.Index>) -> UInt32 {
+            return data.subdata(in: range).withUnsafeBytes { $0.load(as: UInt32.self) }
+        }
+
+        guard data.count >= 12 else {
+            throw GLBError(errorDescription: "Invalid GLB header")
+        }
+        let magic = readUInt32LE(0..<4)
+        guard magic == 0x46546c67 else { // "glTF"
+            throw GLBError(errorDescription: "Invalid magic")
+        }
+        let version = readUInt32LE(4..<8)
+        guard version == 2 else {
+            throw GLBError(errorDescription: "Unsupported GLB version")
+        }
+        let length = Int(readUInt32LE(8..<12))
+        guard length <= data.count else {
+            throw GLBError(errorDescription: "Length mismatch")
+        }
+        var offset = 12
+        guard offset + 8 <= data.count else {
+            throw GLBError(errorDescription: "Missing JSON chunk header")
+        }
+        let jsonLength = Int(readUInt32LE(offset..<(offset+4)))
+        let jsonType = readUInt32LE((offset+4)..<(offset+8))
+        guard jsonType == 0x4E4F534A else { // "JSON"
+            throw GLBError(errorDescription: "First chunk is not JSON")
+        }
+        offset += 8
+        guard offset + jsonLength <= data.count else {
+            throw GLBError(errorDescription: "JSON chunk out of range")
+        }
+        let jsonData = data.subdata(in: offset..<(offset+jsonLength))
+        let decoder = JSONDecoder()
+        let gltf = try decoder.decode(GLTF.self, from: jsonData)
+        offset += (jsonLength + 3) & ~3 // align 4
+
+        var binaryChunk: Data? = nil
+        if offset < data.count {
+            guard offset + 8 <= data.count else {
+                throw GLBError(errorDescription: "Missing BIN chunk header")
+            }
+            let binLength = Int(readUInt32LE(offset..<(offset+4)))
+            let binType = readUInt32LE((offset+4)..<(offset+8))
+            guard binType == 0x004E4942 else { // "BIN\0"
+                throw GLBError(errorDescription: "Second chunk is not BIN")
+            }
+            offset += 8
+            guard offset + binLength <= data.count else {
+                throw GLBError(errorDescription: "BIN chunk out of range")
+            }
+            binaryChunk = data.subdata(in: offset..<(offset+binLength))
+        }
+        return (gltf, binaryChunk)
+    }
+}

--- a/Sources/SwiftGLTFCore/Loader.swift
+++ b/Sources/SwiftGLTFCore/Loader.swift
@@ -5,13 +5,15 @@ public struct GLTFBufferLoader {
     public let baseURL: URL
     public let loadedBuffers: [Data]
 
-    public init(gltf: GLTF, baseURL: URL) throws {
+    public init(gltf: GLTF, baseURL: URL, binaryChunk: Data? = nil) throws {
         self.gltf = gltf
         self.baseURL = baseURL
-        self.loadedBuffers = try gltf.buffers?.map { buffer in
+        self.loadedBuffers = try gltf.buffers?.enumerated().map { index, buffer in
             if let uri = buffer.uri {
                 let bufferURL = baseURL.appendingPathComponent(uri)
                 return try Data(contentsOf: bufferURL)
+            } else if index == 0, let binaryChunk {
+                return binaryChunk
             } else {
                 throw NSError(domain: "GLTF", code: -1, userInfo: [NSLocalizedDescriptionKey: "Buffer URI is missing"])
             }

--- a/Tests/SwiftGLTFTests/Cube/CubeTests.swift
+++ b/Tests/SwiftGLTFTests/Cube/CubeTests.swift
@@ -205,6 +205,28 @@ struct CubeTests {
         #expect(roughness?.floatValue == 0.5)
     }
 
+    @Test
+    func testLoadGLB() throws {
+        guard let glbURL = Bundle.module.url(forResource: "cube", withExtension: "glb") else {
+            throw NSError(domain: "CubeGLTFTests", code: -1, userInfo: [NSLocalizedDescriptionKey: "cube.glb not found"])
+        }
+        let data = try Data(contentsOf: glbURL)
+        let (gltf, bin) = try loadGLB(from: data)
+        let asset = try makeMDLAsset(
+            from: gltf,
+            baseURL: glbURL.deletingLastPathComponent(),
+            binaryChunk: bin,
+            options: GLTFDecodeOptions(
+                convertToLeftHanded: false,
+                autoScale: false,
+                generateNormalVertexIfNeeded: false,
+                generateTangentVertexIfNeeded: false
+            )
+        )
+        let mesh = asset.object(at: 0).children.objects[0] as! MDLMesh
+        #expect(mesh.vertexCount == 24)
+    }
+
     // MARK: - Helper Methods
 
     private func loadGLTFAndAsset() throws -> (GLTF, MDLAsset) {


### PR DESCRIPTION
## Summary
- support decoding .glb files via new `GLBDecoder`
- allow `GLTFBufferLoader` to load binary chunks
- expose `loadGLB` and update `makeMDLAsset`
- test `.glb` decoding with cube resource
- document GLB usage in README
- remove test `.glb` resource from repository

## Testing
- `swift test` *(fails: no such module 'Metal')*


------
https://chatgpt.com/codex/tasks/task_e_686bbdf738dc832d856e75a34d202040