### PR TITLE
Add texcoord1 support

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -120,7 +120,7 @@ var body: some View {
 | NORMAL        | ✅         |
 | TANGENT       | ✅         |
 | TEXCOORD_0    | ✅         |
-| TEXCOORD_1    | ❌         |
+| TEXCOORD_1    | ✅         |
 | COLOR_0       | ✅         |
 | JOINTS_0      | ❌         |
 | WEIGHTS_0     | ❌         |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ var body: some View {
 | NORMAL        | ✅         |
 | TANGENT       | ✅         |
 | TEXCOORD_0    | ✅         |
-| TEXCOORD_1    | ❌         |
+| TEXCOORD_1    | ✅         |
 | COLOR_0       | ✅         |
 | JOINTS_0      | ❌         |
 | WEIGHTS_0     | ❌         |

--- a/Sources/SwiftGLTF/MaterialPropertyName.swift
+++ b/Sources/SwiftGLTF/MaterialPropertyName.swift
@@ -2,13 +2,18 @@ import Foundation
 
 public enum MaterialPropertyName: String {
     case normalTexture
+    case normalTexcoord
     case baseColorFactor
     case baseColorTexture
+    case baseColorTexcoord
     case metallic
     case roughness
     case metallicRoughnessTexture
+    case metallicRoughnessTexcoord
     case emissiveFactor
     case emissiveTexture
+    case emissiveTexcoord
     case occlusion
+    case occlusionTexcoord
     case occlusionStrength
 }

--- a/Sources/SwiftGLTFRenderer/Model/BridgingTypes.swift
+++ b/Sources/SwiftGLTFRenderer/Model/BridgingTypes.swift
@@ -20,6 +20,15 @@ struct PBRSceneUniforms {
 
 struct PBRVertexUniforms {
     let hasTangent: Bool // Indicates if tangents are present
-    let hasUV: Bool // Indicates if texture coordinates are present
+    let hasUV0: Bool // Indicates if TEXCOORD_0 is present
+    let hasUV1: Bool // Indicates if TEXCOORD_1 is present
     let hasModulationColor: Bool // Indicates if vertex colors are present
+}
+
+struct PBRTexcoordIndices {
+    let baseColor: UInt32
+    let normal: UInt32
+    let metallicRoughness: UInt32
+    let emissive: UInt32
+    let occlusion: UInt32
 }

--- a/Sources/SwiftGLTFRenderer/Model/PBRMesh.swift
+++ b/Sources/SwiftGLTFRenderer/Model/PBRMesh.swift
@@ -23,5 +23,6 @@ struct PBRMesh {
         let emissiveSampler: MTLSamplerState?
         let occlusionTexture: MTLTexture?
         let occlusionSampler: MTLSamplerState?
+        let texcoordIndicesBuffer: MTLBuffer
     }
 }

--- a/Sources/SwiftGLTFRenderer/Model/PBRPipelineStateLoader.swift
+++ b/Sources/SwiftGLTFRenderer/Model/PBRPipelineStateLoader.swift
@@ -57,9 +57,14 @@ public class PBRPipelineStateLoader {
         default:
             false
         }
-        let typeFloat2Texcoord = switch (vertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_0] as? MDLVertexAttribute)?.format {
+        let typeFloat2Texcoord0 = switch (vertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_0] as? MDLVertexAttribute)?.format {
         case .float2, .invalid:
-            // invalid format is also acceptable for texcoord because it can be optional
+            true
+        default:
+            false
+        }
+        let typeFloat2Texcoord1 = switch (vertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_1] as? MDLVertexAttribute)?.format {
+        case .float2, .invalid:
             true
         default:
             false
@@ -72,7 +77,7 @@ public class PBRPipelineStateLoader {
             false
         }
 
-        if existFloat3Position && existFloat3Normal && typeFloat4Tangent && typeFloat2Texcoord && typeFloat4Color {
+        if existFloat3Position && existFloat3Normal && typeFloat4Tangent && typeFloat2Texcoord0 && typeFloat4Color {
             return
         } else {
             throw NSError(
@@ -83,7 +88,8 @@ public class PBRPipelineStateLoader {
                 - Position (float3)
                 - Normal (float3)
                 - Tangent (float4, optional)
-                - Texcoord (float2, optional)
+                - Texcoord0 (float2, optional)
+                - Texcoord1 (float2, optional)
                 - Color (float4, optional)
                 
                 ---
@@ -92,7 +98,8 @@ public class PBRPipelineStateLoader {
                 Position: \(existFloat3Position ? "✓" : "✗")
                 Normal: \(existFloat3Normal ? "✓" : "✗")
                 Tangent: \(typeFloat4Tangent ? "✓" : "✗")
-                Texcoord: \(typeFloat2Texcoord ? "✓" : "✗")
+                Texcoord0: \(typeFloat2Texcoord0 ? "✓" : "✗")
+                Texcoord1: \(typeFloat2Texcoord1 ? "✓" : "✗")
                 Color: \(typeFloat4Color ? "✓" : "✗")
                 Please check your MDLVertexDescriptor configuration.
                 """]
@@ -122,11 +129,17 @@ public class PBRPipelineStateLoader {
         mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TANGENT].bufferIndex = 0
         offset += mdlVertexDescriptor.validTangentVertex ? 16 : 0
 
-        // texcoord
+        // texcoord0
         mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_0].format = .float2
         mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_0].offset = offset
         mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_0].bufferIndex = 0
-        offset += mdlVertexDescriptor.validTexcoordVertex ? 8 : 0
+        offset += mdlVertexDescriptor.validTexcoord0Vertex ? 8 : 0
+
+        // texcoord1
+        mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_1].format = .float2
+        mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_1].offset = offset
+        mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.TEXCOORD_1].bufferIndex = 0
+        offset += mdlVertexDescriptor.validTexcoord1Vertex ? 8 : 0
 
         // color
         mtlVertexDescriptor.attributes[GLTFVertexAttributeIndex.COLOR_0].format = .float4
@@ -150,8 +163,13 @@ extension MDLVertexDescriptor {
         return tangentAttribute?.format == .float4
     }
 
-    var validTexcoordVertex: Bool {
+    var validTexcoord0Vertex: Bool {
         let texcoordAttribute = attributes[GLTFVertexAttributeIndex.TEXCOORD_0] as? MDLVertexAttribute
+        return texcoordAttribute?.format == .float2
+    }
+
+    var validTexcoord1Vertex: Bool {
+        let texcoordAttribute = attributes[GLTFVertexAttributeIndex.TEXCOORD_1] as? MDLVertexAttribute
         return texcoordAttribute?.format == .float2
     }
 

--- a/Sources/SwiftGLTFRenderer/View/render.swift
+++ b/Sources/SwiftGLTFRenderer/View/render.swift
@@ -42,6 +42,7 @@ func drawPBR(
     renderEncoder.setVertexBuffer(externalTransform, offset: 0, index: 4)
     renderEncoder.setFragmentBuffer(mesh.vertexUniformsBuffer, offset: 0, index: 0)
     renderEncoder.setFragmentBuffer(pbrSceneUniformsBuffer, offset: 0, index: 1)
+    // texcoord indices buffer will be set per submesh at index 2
     renderEncoder.setFragmentTexture(specularCubeMapTexture, index: 0)
     renderEncoder.setFragmentTexture(irradianceCubeMapTexture, index: 1)
     renderEncoder.setFragmentTexture(brdfLUT, index: 2)
@@ -58,6 +59,7 @@ func drawPBR(
         renderEncoder.setFragmentSamplerState(submesh.emissiveSampler, index: 3)
         renderEncoder.setFragmentTexture(submesh.occlusionTexture, index: 7)
         renderEncoder.setFragmentSamplerState(submesh.occlusionSampler, index: 4)
+        renderEncoder.setFragmentBuffer(submesh.texcoordIndicesBuffer, offset: 0, index: 2)
 
         renderEncoder.drawIndexedPrimitives(
             type: submesh.primitiveType,

--- a/Sources/SwiftGLTFShaderTypes/includes/pbr.h
+++ b/Sources/SwiftGLTFShaderTypes/includes/pbr.h
@@ -11,8 +11,17 @@ typedef struct {
 
 typedef struct {
     bool hasTangent;
-    bool hasUV;
+    bool hasUV0;
+    bool hasUV1;
     bool hasModulationColor;
 } PBRVertexUniforms;
+
+typedef struct {
+    uint baseColor;
+    uint normal;
+    uint metallicRoughness;
+    uint emissive;
+    uint occlusion;
+} PBRTexcoordIndices;
 
 #endif /* PBR_h */


### PR DESCRIPTION
## Summary
- support `TEXCOORD_1`
- add MDL material properties for texture coordinate set
- send texture coordinate indices to Metal shader
- update shaders and pipeline for uv1
- document texcoord1 support

## Testing
- `swift test` *(fails: no such module 'ModelIO')*

------
https://chatgpt.com/codex/tasks/task_e_6884da34ff08832d86b4ac11a1b02e24