### PR TITLE
Refactor errors into module-specific types

### DIFF
--- a/Sources/SwiftGLTF/GLTFView.swift
+++ b/Sources/SwiftGLTF/GLTFView.swift
@@ -85,7 +85,7 @@ public class GLTFView: MTKView {
         if let commandQueue = device.makeCommandQueue() {
             self.commandQueue = commandQueue
         } else {
-            throw SwiftGLTFError.swiftgltf(description: "Failed to create command queue")
+            throw SwiftGLTFError(description: "Failed to create command queue")
         }
 
         let sampleCount = 4

--- a/Sources/SwiftGLTF/MTKDeviceSupported.swift
+++ b/Sources/SwiftGLTF/MTKDeviceSupported.swift
@@ -4,9 +4,9 @@ import SwiftGLTFCore
 public func checkSwiftGLTFMTKDeviceSupported(device: MTLDevice) throws {
     // Check for argument buffer support
     guard device.argumentBuffersSupport == .tier2 else {
-        throw SwiftGLTFError.swiftgltf(description: "Unsupported feature: Metal Argument Buffers Tier 2")
+        throw SwiftGLTFError(description: "Unsupported feature: Metal Argument Buffers Tier 2")
     }
     guard device.supportsFamily(.apple6) || device.supportsFamily(.mac2) else {
-        throw SwiftGLTFError.swiftgltf(description: "Unsupported feature: Metal Family Apple6 or Mac2")
+        throw SwiftGLTFError(description: "Unsupported feature: Metal Family Apple6 or Mac2")
     }
 }

--- a/Sources/SwiftGLTF/SwiftGLTFError.swift
+++ b/Sources/SwiftGLTF/SwiftGLTFError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct SwiftGLTFError: Error, Sendable {
+    public let description: String
+
+    public init(description: String) {
+        self.description = description
+    }
+}
+
+extension SwiftGLTFError: LocalizedError {
+    public var errorDescription: String? {
+        "[SwiftGLTF] \(description)"
+    }
+}
+
+extension SwiftGLTFError: CustomNSError {
+    public static var errorDomain: String { "com.swiftgltf" }
+
+    public var errorCode: Int { 0 }
+
+    public var errorUserInfo: [String: Any] {
+        [NSLocalizedDescriptionKey: self.errorDescription ?? "SwiftGLTFError"]
+    }
+}

--- a/Sources/SwiftGLTFCore/Loader.swift
+++ b/Sources/SwiftGLTFCore/Loader.swift
@@ -8,11 +8,11 @@ import Accelerate
 func dataFromDataURI(_ uri: String) throws -> Data {
     // Extract base64 string after comma
     guard let comma = uri.firstIndex(of: ",") else {
-        throw SwiftGLTFError.core(description: "Invalid data URI")
+        throw SwiftGLTFCoreError(description: "Invalid data URI")
     }
     let b64 = String(uri[uri.index(after: comma)...])
     guard let data = Data(base64Encoded: b64) else {
-        throw SwiftGLTFError.core(description: "Failed to decode base64 data")
+        throw SwiftGLTFCoreError(description: "Failed to decode base64 data")
     }
     return data
 }
@@ -21,7 +21,7 @@ func makeMDLTexture(from data: Data, name: String) throws -> MDLTexture {
     guard
         let src = CGImageSourceCreateWithData(data as CFData, nil),
         let cgImage = CGImageSourceCreateImageAtIndex(src, 0, nil)
-    else { throw SwiftGLTFError.core(description: "Failed to create CGImage from data") }
+    else { throw SwiftGLTFCoreError(description: "Failed to create CGImage from data") }
 
     let properties = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any]
     let bitsPerComponent = properties?[kCGImagePropertyDepth] as? Int ?? 8
@@ -35,13 +35,13 @@ func makeMDLTexture(from data: Data, name: String) throws -> MDLTexture {
         bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue),
         renderingIntent: .defaultIntent
     ) else {
-        throw SwiftGLTFError.core(description: "Invalid CGImage format")
+        throw SwiftGLTFCoreError(description: "Invalid CGImage format")
     }
 
     var buffer = vImage_Buffer()
     let kvFlags = vImage_Flags(kvImageNoFlags)
     let initErr = vImageBuffer_InitWithCGImage(&buffer, &format, nil, cgImage, kvFlags)
-    guard initErr == kvImageNoError else { throw SwiftGLTFError.core(description: "Failed to initialize vImage buffer") }
+    guard initErr == kvImageNoError else { throw SwiftGLTFCoreError(description: "Failed to initialize vImage buffer") }
 
     let bufferRowBytes = Int(buffer.rowBytes)
     let imageRowBytes = Int(buffer.width * 4)
@@ -80,23 +80,23 @@ func isGLB(_ data: Data) -> Bool {
 
 private func loadFromGLB(_ data: Data) throws -> GLTFBundle {
     guard data.count >= 12 else {
-        throw SwiftGLTFError.core(description: "GLB data too short for header")
+        throw SwiftGLTFCoreError(description: "GLB data too short for header")
     }
 
     let magic = data.prefix(4)
     let expectedMagic = Data([0x67, 0x6C, 0x54, 0x46])
     guard magic == expectedMagic else {
-        throw SwiftGLTFError.core(description: "Invalid GLB magic header")
+        throw SwiftGLTFCoreError(description: "Invalid GLB magic header")
     }
 
     let version: UInt32 = data[4..<8].withUnsafeBytes { $0.load(as: UInt32.self) }.littleEndian
     guard version == 2 else {
-        throw SwiftGLTFError.core(description: "Unsupported GLB version: \(version)")
+        throw SwiftGLTFCoreError(description: "Unsupported GLB version: \(version)")
     }
 
     let totalLength: UInt32 = data[8..<12].withUnsafeBytes { $0.load(as: UInt32.self) }.littleEndian
     guard totalLength == data.count else {
-        throw SwiftGLTFError.core(description: "GLB length mismatch")
+        throw SwiftGLTFCoreError(description: "GLB length mismatch")
     }
 
     var offset = 12
@@ -109,7 +109,7 @@ private func loadFromGLB(_ data: Data) throws -> GLTFBundle {
         let chunkStart = offset + 8
         let chunkEnd = chunkStart + Int(chunkLength)
         guard chunkEnd <= data.count else {
-            throw SwiftGLTFError.core(description: "GLB chunk exceeds data bounds")
+            throw SwiftGLTFCoreError(description: "GLB chunk exceeds data bounds")
         }
 
         let chunk = data.subdata(in: chunkStart..<chunkEnd)
@@ -125,20 +125,20 @@ private func loadFromGLB(_ data: Data) throws -> GLTFBundle {
     }
 
     guard let jsonChunk else {
-        throw SwiftGLTFError.core(description: "JSON chunk not found in GLB")
+        throw SwiftGLTFCoreError(description: "JSON chunk not found in GLB")
     }
     let decoder = JSONDecoder()
     let gltf = try decoder.decode(GLTF.self, from: jsonChunk)
 
     guard let binChunk else {
-        throw SwiftGLTFError.core(description: "BIN chunk not found in GLB")
+        throw SwiftGLTFCoreError(description: "BIN chunk not found in GLB")
     }
 
     // Extract embedded images from bufferViews
     var textures: [MDLTexture] = []
     if let images = gltf.images {
         guard let bufferViews = gltf.bufferViews else {
-            throw SwiftGLTFError.core(description: "Image bufferView is missing for image 0")
+            throw SwiftGLTFCoreError(description: "Image bufferView is missing for image 0")
         }
         for (idx, image) in images.enumerated() {
             if let bvIndex = image.bufferView?.value {
@@ -150,7 +150,7 @@ private func loadFromGLB(_ data: Data) throws -> GLTFBundle {
                 let texture = try makeMDLTexture(from: imageData, name: "Texture_\(idx)")
                 textures.append(texture)
             } else {
-                throw SwiftGLTFError.core(description: "Image bufferView is missing for image \(idx)")
+                throw SwiftGLTFCoreError(description: "Image bufferView is missing for image \(idx)")
             }
         }
     }
@@ -169,18 +169,18 @@ private func loadFromGLTF(_ data: Data, baseURL: URL) throws -> GLTFBundle {
             if uri.hasPrefix("data:") {
                 // Data URI: data:<mime>;base64,<data>
                 guard let comma = uri.firstIndex(of: ",") else {
-                    throw SwiftGLTFError.core(description: "Invalid data URI")
+                    throw SwiftGLTFCoreError(description: "Invalid data URI")
                 }
                 let b64 = String(uri[uri.index(after: comma)...])
                 guard let decoded = Data(base64Encoded: b64) else {
-                    throw SwiftGLTFError.core(description: "Failed to decode base64 data")
+                    throw SwiftGLTFCoreError(description: "Failed to decode base64 data")
                 }
                 data = decoded
             } else {
                 data = try Data(contentsOf: url)
             }
         } else {
-            throw SwiftGLTFError.core(description: "Buffer URI is missing or empty")
+            throw SwiftGLTFCoreError(description: "Buffer URI is missing or empty")
         }
         buffers.append(data)
     }
@@ -200,10 +200,10 @@ private func loadFromGLTF(_ data: Data, baseURL: URL) throws -> GLTFBundle {
                 let texture = try makeMDLTexture(from: imageData, name: "Texture_\(idx)")
                 textures.append(texture)
             } else {
-                throw SwiftGLTFError.core(description: "Image URI is missing or invalid")
+                throw SwiftGLTFCoreError(description: "Image URI is missing or invalid")
             }
         } else {
-            throw SwiftGLTFError.core(description: "Image URI is missing or invalid")
+            throw SwiftGLTFCoreError(description: "Image URI is missing or invalid")
         }
     }
     return GLTFBundle(gltf: gltf, binaryBuffers: buffers, binaryTextures: textures)
@@ -233,18 +233,18 @@ public class GLTFBinaryLoader {
         let binaryBuffers = gltfBundle.binaryBuffers
 
         guard let accessors = gltf.accessors, accessorIndex.value < accessors.count else {
-            throw SwiftGLTFError.core(description: "Buffer index out of range")
+            throw SwiftGLTFCoreError(description: "Buffer index out of range")
         }
         let accessor = accessors[accessorIndex.value]
         guard let bufferViews = gltf.bufferViews,
               let bvIndex = accessor.bufferView?.value,
               bvIndex < bufferViews.count else {
-            throw SwiftGLTFError.core(description: "Buffer index out of range")
+            throw SwiftGLTFCoreError(description: "Buffer index out of range")
         }
         let bv = bufferViews[bvIndex]
         let bufIdx = bv.buffer.value
         guard bufIdx < binaryBuffers.count else {
-            throw SwiftGLTFError.core(description: "Buffer index out of range")
+            throw SwiftGLTFCoreError(description: "Buffer index out of range")
         }
         let bufferData = binaryBuffers[bufIdx]
         let baseOffset = accessor.byteOffset + bv.byteOffset
@@ -254,7 +254,7 @@ public class GLTFBinaryLoader {
         let diffStride = bufferStride - accessorStride
         let endOffset = baseOffset + totalLength - diffStride
         guard endOffset <= bufferData.count else {
-            throw SwiftGLTFError.core(description: "Buffer overrun in accessor data")
+            throw SwiftGLTFCoreError(description: "Buffer overrun in accessor data")
         }
         var slice = bufferData.subdata(in: baseOffset..<endOffset)
         if diffStride != 0 {
@@ -278,7 +278,7 @@ public class GLTFBinaryLoader {
         let binaryTextures = gltfBundle.binaryTextures
 
         guard textureIndex.value < binaryTextures.count else {
-            throw SwiftGLTFError.core(description: "Texture index out of range")
+            throw SwiftGLTFCoreError(description: "Texture index out of range")
         }
         return binaryTextures[textureIndex.value]
     }

--- a/Sources/SwiftGLTFCore/SwiftGLTFError.swift
+++ b/Sources/SwiftGLTFCore/SwiftGLTFError.swift
@@ -1,33 +1,25 @@
 import Foundation
 
-public enum SwiftGLTFError: Error, Sendable {
-    case core(description: String)
-    case parser(description: String)
-    case render(description: String)
-    case swiftgltf(description: String)
-}
+public struct SwiftGLTFCoreError: Error, Sendable {
+    public let description: String
 
-extension SwiftGLTFError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case let .core(description):
-            return "[SwiftGLTF][Core] \(description)"
-        case let .parser(description):
-            return "[SwiftGLTF][Parser] \(description)"
-        case let .render(description):
-            return "[SwiftGLTF][Render] \(description)"
-        case let .swiftgltf(description):
-            return "[SwiftGLTF] \(description)"
-        }
+    public init(description: String) {
+        self.description = description
     }
 }
 
-extension SwiftGLTFError: CustomNSError {
-    public static var errorDomain: String { "com.swiftgltf.error" }
+extension SwiftGLTFCoreError: LocalizedError {
+    public var errorDescription: String? {
+        "[SwiftGLTFCore] \(description)"
+    }
+}
+
+extension SwiftGLTFCoreError: CustomNSError {
+    public static var errorDomain: String { "com.swiftgltf.core" }
 
     public var errorCode: Int { 0 }
 
-    public var errorUserInfo: [String : Any] {
-        [NSLocalizedDescriptionKey: self.errorDescription ?? "SwiftGLTFError"]
+    public var errorUserInfo: [String: Any] {
+        [NSLocalizedDescriptionKey: self.errorDescription ?? "SwiftGLTFCoreError"]
     }
 }

--- a/Sources/SwiftGLTFParser/IndexInfo.swift
+++ b/Sources/SwiftGLTFParser/IndexInfo.swift
@@ -37,7 +37,7 @@ struct IndexInfo {
                 }
                 return intArray
             default:
-                throw SwiftGLTFError.parser(description: "Unsupported index type for normal generation")
+                throw SwiftGLTFParserError(description: "Unsupported index type for normal generation")
             }
         }
     }

--- a/Sources/SwiftGLTFParser/SwiftGLTFParserError.swift
+++ b/Sources/SwiftGLTFParser/SwiftGLTFParserError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct SwiftGLTFParserError: Error, Sendable {
+    public let description: String
+
+    public init(description: String) {
+        self.description = description
+    }
+}
+
+extension SwiftGLTFParserError: LocalizedError {
+    public var errorDescription: String? {
+        "[SwiftGLTFParser] \(description)"
+    }
+}
+
+extension SwiftGLTFParserError: CustomNSError {
+    public static var errorDomain: String { "com.swiftgltf.parser" }
+
+    public var errorCode: Int { 0 }
+
+    public var errorUserInfo: [String: Any] {
+        [NSLocalizedDescriptionKey: self.errorDescription ?? "SwiftGLTFParserError"]
+    }
+}

--- a/Sources/SwiftGLTFParser/parser.swift
+++ b/Sources/SwiftGLTFParser/parser.swift
@@ -616,15 +616,15 @@ private func makePositionVertex(
     binaryLoader: GLTFBinaryLoader
 ) throws -> VertexInfo {
     guard let positionAccessorIndex = primitive.attributes[GLTFAttribute.position.rawValue] else {
-        throw SwiftGLTFError.parser(description: "Missing attribute: POSITION")
+        throw SwiftGLTFParserError(description: "Missing attribute: POSITION")
     }
     guard accessors.count > positionAccessorIndex else {
-        throw SwiftGLTFError.parser(description: "Invalid accessor index for POSITION: \(positionAccessorIndex)")
+        throw SwiftGLTFParserError(description: "Invalid accessor index for POSITION: \(positionAccessorIndex)")
     }
 
     let positionAccessor = accessors[positionAccessorIndex]
     guard let positionVertexFormat = getMDLVertexFormat(accessor: positionAccessor) else {
-        throw SwiftGLTFError.parser(description: "Invalid accessor: POSITION")
+        throw SwiftGLTFParserError(description: "Invalid accessor: POSITION")
     }
     let positionVertex = VertexInfo(
         data: try binaryLoader.extractData(accessorIndex: AccessorIndex(positionAccessorIndex)),
@@ -715,7 +715,7 @@ private func makeJointVertex(
     }
     let accessor = accessors[attrIndex]
     guard accessor.type == .vec4 else {
-        throw SwiftGLTFError.parser(description: "JOINTS_0 vertex must be VEC4")
+        throw SwiftGLTFParserError(description: "JOINTS_0 vertex must be VEC4")
     }
     switch accessor.componentType {
     case .unsignedByte, .unsignedShort:
@@ -741,7 +741,7 @@ private func makeJointVertex(
             return VertexInfo(data: out, componentFormat: .uShort4, componentSize: MemoryLayout<UInt16>.size * 4)
         }
     default:
-        throw SwiftGLTFError.parser(description: "JOINTS_0 vertex must be uByte4 or uShort4")
+        throw SwiftGLTFParserError(description: "JOINTS_0 vertex must be uByte4 or uShort4")
     }
 }
 
@@ -755,7 +755,7 @@ private func makeWeightVertex(
     }
     let accessor = accessors[attrIndex]
     guard accessor.type == .vec4 else {
-        throw SwiftGLTFError.parser(description: "WEIGHTS_0 vertex must be VEC4")
+        throw SwiftGLTFParserError(description: "WEIGHTS_0 vertex must be VEC4")
     }
     let count = accessor.count
     switch accessor.componentType {
@@ -812,7 +812,7 @@ private func makeWeightVertex(
         }
         return VertexInfo(data: out, componentFormat: .float4, componentSize: MemoryLayout<Float>.size * 4)
     default:
-        throw SwiftGLTFError.parser(description: "WEIGHTS_0 vertex must be float4|uByte4|uShort4")
+        throw SwiftGLTFParserError(description: "WEIGHTS_0 vertex must be float4|uByte4|uShort4")
     }
 }
 
@@ -824,7 +824,7 @@ private func makeIndexInfo(
 ) throws -> IndexInfo {
     if let indexAccessorIndex = primitive.indices {
         guard accessors.count > indexAccessorIndex.value else {
-            throw SwiftGLTFError.parser(description: "Invalid indices reference")
+            throw SwiftGLTFParserError(description: "Invalid indices reference")
         }
 
         let accessor = accessors[indexAccessorIndex.value]
@@ -837,7 +837,7 @@ private func makeIndexInfo(
         case .unsignedShort: indexType = .uInt16
         case .unsignedInt: indexType = .uInt32
         default:
-            throw SwiftGLTFError.parser(description: "Unsupported index type")
+            throw SwiftGLTFParserError(description: "Unsupported index type")
         }
 
         return IndexInfo(
@@ -876,42 +876,42 @@ private func makeVertexDescriptor(
 
     let positionIsFloat3 = positionVertex.componentFormat == .float3
     if !positionIsFloat3 {
-        throw SwiftGLTFError.parser(description: "POSITION vertex must be float3")
+        throw SwiftGLTFParserError(description: "POSITION vertex must be float3")
     }
     if let normalVertex {
         let normalIsFloat3 = normalVertex.componentFormat == .float3
         if !normalIsFloat3 {
-            throw SwiftGLTFError.parser(description: "NORMAL vertex must be float3")
+            throw SwiftGLTFParserError(description: "NORMAL vertex must be float3")
         }
     }
     if let tangentVertex {
         if tangentVertex.componentFormat != .float4 {
-            throw SwiftGLTFError.parser(description: "TANGENT vertex must be float4")
+            throw SwiftGLTFParserError(description: "TANGENT vertex must be float4")
         }
     }
     if let texcoordVertex0 {
         if texcoordVertex0.componentFormat != .float2 {
-            throw SwiftGLTFError.parser(description: "TEXCOORD vertex must be float2")
+            throw SwiftGLTFParserError(description: "TEXCOORD vertex must be float2")
         }
     }
     if let texcoordVertex1 {
         if texcoordVertex1.componentFormat != .float2 {
-            throw SwiftGLTFError.parser(description: "TEXCOORD vertex must be float2")
+            throw SwiftGLTFParserError(description: "TEXCOORD vertex must be float2")
         }
     }
     if let modulationColorVertex {
         if modulationColorVertex.componentFormat != .float3 && modulationColorVertex.componentFormat != .float4 {
-            throw SwiftGLTFError.parser(description: "COLOR vertex must be float3 or float4")
+            throw SwiftGLTFParserError(description: "COLOR vertex must be float3 or float4")
         }
     }
     if let jointsVertex {
         if jointsVertex.componentFormat != .uShort4 {
-            throw SwiftGLTFError.parser(description: "JOINTS_0 vertex must be uShort4")
+            throw SwiftGLTFParserError(description: "JOINTS_0 vertex must be uShort4")
         }
     }
     if let weightsVertex {
         if weightsVertex.componentFormat != .float4 {
-            throw SwiftGLTFError.parser(description: "WEIGHTS_0 vertex must be float4")
+            throw SwiftGLTFParserError(description: "WEIGHTS_0 vertex must be float4")
         }
     }
 
@@ -1792,14 +1792,14 @@ private func extractMorphVec3Data(
     options: GLTFDecodeOptions
 ) throws -> Data {
     guard accessors.indices.contains(accessorIndex) else {
-        throw SwiftGLTFError.parser(description: "Invalid accessor index for morph \(attributeName): \(accessorIndex)")
+        throw SwiftGLTFParserError(description: "Invalid accessor index for morph \(attributeName): \(accessorIndex)")
     }
     let accessor = accessors[accessorIndex]
     guard accessor.type == .vec3, accessor.componentType == .float else {
-        throw SwiftGLTFError.parser(description: "Invalid accessor: morph \(attributeName): must be VEC3 with FLOAT components")
+        throw SwiftGLTFParserError(description: "Invalid accessor: morph \(attributeName): must be VEC3 with FLOAT components")
     }
     guard accessor.count == vertexCount else {
-        throw SwiftGLTFError.parser(description: "Invalid accessor: morph \(attributeName): vertex count mismatch")
+        throw SwiftGLTFParserError(description: "Invalid accessor: morph \(attributeName): vertex count mismatch")
     }
     var data = try binaryLoader.extractData(accessorIndex: AccessorIndex(accessorIndex))
     if options.convertToLeftHanded {

--- a/Sources/SwiftGLTFRenderer/Model/EnvironmentMapLoader.swift
+++ b/Sources/SwiftGLTFRenderer/Model/EnvironmentMapLoader.swift
@@ -40,7 +40,7 @@ public class EnvironmentMapLoader {
               let brdfLUTCB = commandQueue.makeDebuggableCommandBuffer(),
               let sheenEnvMapCB = commandQueue.makeDebuggableCommandBuffer(),
               let blitCB = commandQueue.makeDebuggableCommandBuffer() else {
-            throw SwiftGLTFError.render(description: "Failed to create command buffers.")
+            throw SwiftGLTFRendererError(description: "Failed to create command buffers.")
         }
 
         let (envMap, _) = try encodeGeneratingCubeTexture(
@@ -134,7 +134,7 @@ public class EnvironmentMapLoader {
         MTLTexture  // prefiltered sheen
     ) {
         guard cubeTexture.textureType == .typeCube else {
-            throw SwiftGLTFError.render(description: "Provided texture is not a cube texture.")
+            throw SwiftGLTFRendererError(description: "Provided texture is not a cube texture.")
         }
 
         let prefilterEnvMapTexture = shaderConnection.generatePrefilterEnvMapTexture(envMap: cubeTexture)
@@ -196,7 +196,7 @@ public class EnvironmentMapLoader {
         descriptor.usage = [.shaderRead, .shaderWrite]
         descriptor.storageMode = .shared
         guard let cubeTexture = device.makeTexture(descriptor: descriptor) else {
-            throw SwiftGLTFError.render(description: "Failed to create cube texture")
+            throw SwiftGLTFRendererError(description: "Failed to create cube texture")
         }
 
         let red: UInt8

--- a/Sources/SwiftGLTFRenderer/Model/FrameInFlightTexture.swift
+++ b/Sources/SwiftGLTFRenderer/Model/FrameInFlightTexture.swift
@@ -50,7 +50,7 @@ class PBROffscreenTextureManager {
                 _updateFrameWithSave(size, r)
                 return r
             } else {
-                throw SwiftGLTFError.render(description: "Cached resources missing")
+                throw SwiftGLTFRendererError(description: "Cached resources missing")
             }
         }
 
@@ -122,7 +122,7 @@ class PBROffscreenTextureManager {
         samplerDesc.tAddressMode = .clampToEdge
         samplerDesc.supportArgumentBuffers = true
         guard let screenColorSampler = device.makeSamplerState(descriptor: samplerDesc) else {
-            throw SwiftGLTFError.render(description: "Failed to create screen color sampler")
+            throw SwiftGLTFRendererError(description: "Failed to create screen color sampler")
         }
 
         // Create destination mipmapped texture
@@ -142,7 +142,7 @@ class PBROffscreenTextureManager {
               let sceneTransmissionTexture,
               let screenPrefilterTexture,
               let sceneDepthMSAATexture else {
-            throw SwiftGLTFError.render(description: "Failed to create offscreen textures")
+            throw SwiftGLTFRendererError(description: "Failed to create offscreen textures")
         }
         let resources = PBROffscreenTextureResources(
             screenColorMSAATexture: screenColorMSAATexture,

--- a/Sources/SwiftGLTFRenderer/Model/PBRMeshLoader.swift
+++ b/Sources/SwiftGLTFRenderer/Model/PBRMeshLoader.swift
@@ -37,7 +37,7 @@ public class PBRMeshLoader {
         let defaultSceneIndex = asset.objectSafe(atPath: GLTFAssetPath.scenes)?.component(ofType: GLTFDefaultScene.self)?.index ?? 0
         let sceneIndex = sceneIndex ?? defaultSceneIndex
         guard let scene = asset.objectSafe(atPath: GLTFAssetPath.scene(sceneIndex)) else {
-            throw SwiftGLTFError.render(description: "Scene not found")
+            throw SwiftGLTFRendererError(description: "Scene not found")
         }
         let nodeLevelHierarchy = makeNodeLevelHierarchy(root: scene)
 
@@ -337,7 +337,7 @@ public class PBRMeshLoader {
         variantIndex: Int?
     ) throws -> PBRMesh {
         guard let meshData = meshBufferMap[mdlMesh] else {
-            throw SwiftGLTFError.render(description: "Failed to create mesh")
+            throw SwiftGLTFRendererError(description: "Failed to create mesh")
         }
 
         // Model & Inverse Model matrix buffers
@@ -886,7 +886,7 @@ public class PBRMeshLoader {
         heapDescriptor.storageMode = .private
 
         guard let texturesHeap = device.makeHeap(descriptor: heapDescriptor) else {
-            throw SwiftGLTFError.render(description: "Failed to create textures heap")
+            throw SwiftGLTFRendererError(description: "Failed to create textures heap")
         }
         texturesHeap.label = "[SwiftGLTF] Textures Heap"
         return texturesHeap
@@ -907,10 +907,10 @@ public class PBRMeshLoader {
         heapDescriptor.storageMode = .private
 
         guard heapDescriptor.size > 0 else {
-            throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
         }
         guard let fragmentArgumentHeap = device.makeHeap(descriptor: heapDescriptor) else {
-            throw SwiftGLTFError.render(description: "Failed to create fragment argument heap")
+            throw SwiftGLTFRendererError(description: "Failed to create fragment argument heap")
         }
         fragmentArgumentHeap.label = "[SwiftGLTF] Fragment Heap"
         return fragmentArgumentHeap
@@ -961,10 +961,10 @@ public class PBRMeshLoader {
         heapDescriptor.storageMode = .private
 
         guard heapDescriptor.size > 0 else {
-            throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
         }
         guard let vertexModelHeap = device.makeHeap(descriptor: heapDescriptor) else {
-            throw SwiftGLTFError.render(description: "Failed to create vertex model heap")
+            throw SwiftGLTFRendererError(description: "Failed to create vertex model heap")
         }
         vertexModelHeap.label = "[SwiftGLTF] Vertex Heap"
         return vertexModelHeap
@@ -1078,7 +1078,7 @@ public class PBRMeshLoader {
         if let samplerState = device.makeSamplerState(descriptor: descriptor) {
             return samplerState
         } else {
-            throw SwiftGLTFError.render(description: "Failed to create argument buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create argument buffer")
         }
     }
 

--- a/Sources/SwiftGLTFRenderer/Model/PBRPipelineConnector.swift
+++ b/Sources/SwiftGLTFRenderer/Model/PBRPipelineConnector.swift
@@ -334,7 +334,7 @@ public class PBRPipelineConnector {
         argCount: Int
     ) throws -> MTLBuffer {
         guard let buffer = device.makeBuffer(length: encoder.encodedLength * argCount, options: [.storageModeShared]) else {
-            throw SwiftGLTFError.render(description: "Failed to create argument buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create argument buffer")
         }
         return buffer
     }

--- a/Sources/SwiftGLTFRenderer/Model/PrefilterSceneGenerator.swift
+++ b/Sources/SwiftGLTFRenderer/Model/PrefilterSceneGenerator.swift
@@ -12,7 +12,7 @@ class PrefilterSceneGenerator {
         self.library = try device.makePackageLibrary()
 
         guard let kernel = library.makeFunction(name: "prefilterScene2D") else {
-            throw SwiftGLTFError.render(description: "Failed to find prefilterScene2D kernel function")
+            throw SwiftGLTFRendererError(description: "Failed to find prefilterScene2D kernel function")
         }
         prefilterPSO = try device.makeComputePipelineState(function: kernel)
     }

--- a/Sources/SwiftGLTFRenderer/Model/ShaderConnection.swift
+++ b/Sources/SwiftGLTFRenderer/Model/ShaderConnection.swift
@@ -23,7 +23,7 @@ public class ShaderConnection {
         guard count > 0 else { return outBuffer }
 
         guard let function = library.makeFunction(name: "computeBoundingSphereForMesh") else {
-            throw SwiftGLTFError.render(description: "Failed to create convert shader")
+            throw SwiftGLTFRendererError(description: "Failed to create convert shader")
         }
         let pso = try device.makeComputePipelineState(function: function)
 
@@ -66,7 +66,7 @@ public class ShaderConnection {
         guard count > 0 else { return outBuffer }
 
         guard let function = library.makeFunction(name: "computeBoundingSphereForMesh") else {
-            throw SwiftGLTFError.render(description: "Failed to create convert shader")
+            throw SwiftGLTFRendererError(description: "Failed to create convert shader")
         }
         let pso = try device.makeComputePipelineState(function: function)
 
@@ -98,7 +98,7 @@ public class ShaderConnection {
     func convertSrgb2Linear(textures: [MTLTexture]) throws -> [MTLTexture] {
         let commandBuffer = commandQueue.makeCommandBuffer()!
         guard let convertShader = library.makeFunction(name: "texture_srgb_2_linear_shader") else {
-            throw SwiftGLTFError.render(description: "Failed to create convert shader")
+            throw SwiftGLTFRendererError(description: "Failed to create convert shader")
         }
         let pso = try device.makeComputePipelineState(function: convertShader)
 
@@ -113,7 +113,7 @@ public class ShaderConnection {
             outputTextureDescriptor.arrayLength = texture.arrayLength
             outputTextureDescriptor.usage = [.shaderRead, .shaderWrite]
             guard let outputTexture = texture.device.makeTexture(descriptor: outputTextureDescriptor) else {
-                throw SwiftGLTFError.render(description: "Failed to create output texture")
+                throw SwiftGLTFRendererError(description: "Failed to create output texture")
             }
 
             let computeEncoder = commandBuffer.makeComputeCommandEncoder()!
@@ -162,7 +162,7 @@ public class ShaderConnection {
 
     func encodeConvertSrgb2Linear(_ commandBuffer: MTLCommandBuffer, textures: [MTLTexture]) throws -> [MTLTexture] {
         guard let convertShader = library.makeFunction(name: "texture_srgb_2_linear_shader") else {
-            throw SwiftGLTFError.render(description: "Failed to create convert shader")
+            throw SwiftGLTFRendererError(description: "Failed to create convert shader")
         }
         let pso = try device.makeComputePipelineState(function: convertShader)
 
@@ -177,7 +177,7 @@ public class ShaderConnection {
             outputTextureDescriptor.arrayLength = texture.arrayLength
             outputTextureDescriptor.usage = [.shaderRead, .shaderWrite]
             guard let outputTexture = texture.device.makeTexture(descriptor: outputTextureDescriptor) else {
-                throw SwiftGLTFError.render(description: "Failed to create output texture")
+                throw SwiftGLTFRendererError(description: "Failed to create output texture")
             }
 
             let computeEncoder = commandBuffer.makeComputeCommandEncoder()!
@@ -227,7 +227,7 @@ public class ShaderConnection {
     ) throws -> MTLTexture {
         let results = try moveResourcesToHeap(from: [texture], use: heap)
         guard let firstTexture = results.first else {
-            throw SwiftGLTFError.render(description: "Failed to move texture to heap")
+            throw SwiftGLTFRendererError(description: "Failed to move texture to heap")
         }
         return firstTexture
     }
@@ -237,10 +237,10 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> [MTLTexture] {
         guard let commandBuffer = commandQueue.makeCommandBuffer() else {
-            throw SwiftGLTFError.render(description: "Failed to create command buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create command buffer")
         }
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         var output: [MTLTexture] = []
@@ -290,7 +290,7 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> [MTLTexture] {
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         var output: [MTLTexture] = []
@@ -338,7 +338,7 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> MTLBuffer {
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         let heapBuffer = heap.makeBuffer(
@@ -346,7 +346,7 @@ public class ShaderConnection {
             options: [.storageModePrivate]
         )
         guard let heapBuffer else {
-            throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
         }
 
         encoder.copy(from: buffer, sourceOffset: 0, to: heapBuffer, destinationOffset: 0, size: buffer.length)
@@ -360,10 +360,10 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> [MTLBuffer] {
         guard let commandBuffer = commandQueue.makeCommandBuffer() else {
-            throw SwiftGLTFError.render(description: "Failed to create command buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create command buffer")
         }
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         var heapBuffers: [MTLBuffer] = []
@@ -373,7 +373,7 @@ public class ShaderConnection {
                 length: sourceBuffer.length,
                 options: [.storageModePrivate]
             ) else {
-                throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+                throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
             }
             encoder.copy(
                 from: sourceBuffer,
@@ -397,7 +397,7 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> [MTLBuffer] {
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         var heapBuffers: [MTLBuffer] = []
@@ -407,7 +407,7 @@ public class ShaderConnection {
                 length: sourceBuffer.length,
                 options: [.storageModePrivate]
             ) else {
-                throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+                throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
             }
             encoder.copy(
                 from: sourceBuffer,
@@ -428,10 +428,10 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> MTLBuffer {
         guard let commandBuffer = commandQueue.makeCommandBuffer() else {
-            throw SwiftGLTFError.render(description: "Failed to create command buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create command buffer")
         }
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         let heapBuffer = heap.makeBuffer(
@@ -439,7 +439,7 @@ public class ShaderConnection {
             options: [.storageModePrivate]
         )
         guard let heapBuffer else {
-            throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
         }
 
         encoder.copy(from: buffer, sourceOffset: 0, to: heapBuffer, destinationOffset: 0, size: buffer.length)
@@ -456,7 +456,7 @@ public class ShaderConnection {
         use heap: MTLHeap
     ) throws -> MTLBuffer {
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
 
         let heapBuffer = heap.makeBuffer(
@@ -464,7 +464,7 @@ public class ShaderConnection {
             options: [.storageModePrivate]
         )
         guard let heapBuffer else {
-            throw SwiftGLTFError.render(description: "Failed to create heap buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create heap buffer")
         }
 
         encoder.copy(from: buffer, sourceOffset: 0, to: heapBuffer, destinationOffset: 0, size: buffer.length)
@@ -477,10 +477,10 @@ public class ShaderConnection {
         let length = MemoryLayout<T>.size
         let staging = device.makeBuffer(bytes: valuePtr, length: length, options: .storageModeShared)!
         guard let commandBuffer = commandQueue.makeCommandBuffer() else {
-            throw SwiftGLTFError.render(description: "Failed to create command buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create command buffer")
         }
         guard let encoder = commandBuffer.makeBlitCommandEncoder() else {
-            throw SwiftGLTFError.render(description: "Failed to create blit command encoder")
+            throw SwiftGLTFRendererError(description: "Failed to create blit command encoder")
         }
         encoder.copy(from: staging, sourceOffset: 0, to: dst, destinationOffset: 0, size: length)
         encoder.endEncoding()
@@ -546,7 +546,7 @@ public class ShaderConnection {
         waitFence: MTLFence? = nil
     ) throws -> MTLTexture {
         guard envMap.mipmapLevelCount > 1 else {
-            throw SwiftGLTFError.render(description: "Environment map must have mipmaps for prefiltering.")
+            throw SwiftGLTFRendererError(description: "Environment map must have mipmaps for prefiltering.")
         }
         let prefilterEnvMapKernel = library.makeFunction(name: "prefilterEnvMap")!
         let pso = try device.makeComputePipelineState(function: prefilterEnvMapKernel)

--- a/Sources/SwiftGLTFRenderer/Model/WireframePipelineConnector.swift
+++ b/Sources/SwiftGLTFRenderer/Model/WireframePipelineConnector.swift
@@ -36,7 +36,7 @@ class WireframePipelineConnector {
     ) throws -> MTLBuffer {
         let encoder = vertexFunction.makeArgumentEncoder(bufferIndex: 1)
         guard let buffer = device.makeBuffer(length: encoder.encodedLength, options: [.storageModeShared]) else {
-            throw SwiftGLTFError.render(description: "Failed to create argument buffer")
+            throw SwiftGLTFRendererError(description: "Failed to create argument buffer")
         }
         encoder.setArgumentBuffer(buffer, offset: 0)
 

--- a/Sources/SwiftGLTFRenderer/Model/depthStencilState.swift
+++ b/Sources/SwiftGLTFRenderer/Model/depthStencilState.swift
@@ -8,7 +8,7 @@ func makeLessEqualDepthStencilState(device: MTLDevice) throws -> MTLDepthStencil
     descriptor.isDepthWriteEnabled = true
 
     guard let depthStencilState = device.makeDepthStencilState(descriptor: descriptor) else {
-        throw SwiftGLTFError.render(description: "Failed to create depth stencil state (writeEnabled=true)")
+        throw SwiftGLTFRendererError(description: "Failed to create depth stencil state (writeEnabled=true)")
     }
     return depthStencilState
 }
@@ -20,7 +20,7 @@ func makeLessEqualNoWriteDepthStencilState(device: MTLDevice) throws -> MTLDepth
     descriptor.isDepthWriteEnabled = false
 
     guard let depthStencilState = device.makeDepthStencilState(descriptor: descriptor) else {
-        throw SwiftGLTFError.render(description: "Failed to create depth stencil state (writeEnabled=false)")
+        throw SwiftGLTFRendererError(description: "Failed to create depth stencil state (writeEnabled=false)")
     }
     return depthStencilState
 }

--- a/Sources/SwiftGLTFRenderer/Renderer/WireframeRenderer.swift
+++ b/Sources/SwiftGLTFRenderer/Renderer/WireframeRenderer.swift
@@ -165,7 +165,7 @@ public class WireframeRenderer {
 
         // TODO: env map loading should be optional
         guard let envMapUrl = Bundle.module.url(forResource: "env_map", withExtension: "exr") else {
-            throw SwiftGLTFError.render(description: "Environment map not found")
+            throw SwiftGLTFRendererError(description: "Environment map not found")
         }
         let (
             envMapHeap,

--- a/Sources/SwiftGLTFRenderer/SwiftGLTFRendererError.swift
+++ b/Sources/SwiftGLTFRenderer/SwiftGLTFRendererError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct SwiftGLTFRendererError: Error, Sendable {
+    public let description: String
+
+    public init(description: String) {
+        self.description = description
+    }
+}
+
+extension SwiftGLTFRendererError: LocalizedError {
+    public var errorDescription: String? {
+        "[SwiftGLTFRenderer] \(description)"
+    }
+}
+
+extension SwiftGLTFRendererError: CustomNSError {
+    public static var errorDomain: String { "com.swiftgltf.renderer" }
+
+    public var errorCode: Int { 0 }
+
+    public var errorUserInfo: [String: Any] {
+        [NSLocalizedDescriptionKey: self.errorDescription ?? "SwiftGLTFRendererError"]
+    }
+}

--- a/Tests/SwiftGLTFCoreTests/ErrorTests.swift
+++ b/Tests/SwiftGLTFCoreTests/ErrorTests.swift
@@ -2,18 +2,14 @@ import XCTest
 @testable import SwiftGLTFCore
 
 final class ErrorTests: XCTestCase {
-    func testParseErrorDescription() {
-        let err = SwiftGLTFError.parser(description: "Missing attribute: POSITION")
-        guard case let .parser(description) = err else {
-            XCTFail("not parser error"); return
-        }
-        XCTAssertEqual(description, "Missing attribute: POSITION")
-        XCTAssertEqual(err.errorDescription, "[SwiftGLTF][Parser] Missing attribute: POSITION")
+    func testCoreErrorDescription() {
+        let err = SwiftGLTFCoreError(description: "Missing attribute: POSITION")
+        XCTAssertEqual(err.description, "Missing attribute: POSITION")
+        XCTAssertEqual(err.errorDescription, "[SwiftGLTFCore] Missing attribute: POSITION")
 
         let ns = err as NSError
-        XCTAssertEqual(ns.domain, "com.swiftgltf.error")
+        XCTAssertEqual(ns.domain, "com.swiftgltf.core")
         XCTAssertEqual(ns.code, 0)
-        XCTAssertEqual(ns.userInfo[NSLocalizedDescriptionKey] as? String, "[SwiftGLTF][Parser] Missing attribute: POSITION")
+        XCTAssertEqual(ns.userInfo[NSLocalizedDescriptionKey] as? String, "[SwiftGLTFCore] Missing attribute: POSITION")
     }
 }
-


### PR DESCRIPTION
## Summary
- add dedicated error types for SwiftGLTF, SwiftGLTFCore, SwiftGLTFParser, and SwiftGLTFRenderer with module-prefixed descriptions
- update all modules to throw their local error structs instead of a shared enum
- refresh the core error test to reflect the new SwiftGLTFCoreError behavior

## Testing
- swift test *(fails: `Foundation/Foundation.h` not found when building SwiftGLTFShaderTypes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e9dac13d8832d9ce30bca85b939ed)